### PR TITLE
Prevent two lines in multi-page command help

### DIFF
--- a/src/main/java/org/logblock/Commands.java
+++ b/src/main/java/org/logblock/Commands.java
@@ -91,9 +91,10 @@ public class Commands implements CommandExecutor
 
         if (args.length == 0)
         {
-            sender.sendMessage(ChatColor.GOLD + "=====[Commands]====");
-            if (pages > 1)
-                sender.sendMessage(ChatColor.GOLD + "========[1/" + pages + "]========");
+            if (pages > 1){
+                sender.sendMessage(ChatColor.GOLD + "==[Commands - Page 1/" + pages + "]==");
+                }else sender.sendMessage(ChatColor.GOLD + "=====[Commands]====")
+            
             for (Method method : commandMap.values())
             {
                 AnnotatedCommand annotation = method.getAnnotation(AnnotatedCommand.class);


### PR DESCRIPTION
Reversed 'if(pages>1)' with 'sender.sendMessage' so that both lines won't
show up in the event of command help with many pages.

This will change the following:
====[Commands]====
====[Page 1/#]====

into this for one page:
====[Commands]====

and this for multiple pages:
==[Commands - Page 1/#]==
