### PR TITLE
Update shade plugin to maven 3.1-compatible version

### DIFF
--- a/LogBlock-2-API/pom.xml
+++ b/LogBlock-2-API/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.0</version>
+                <version>2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/Logblock-2-Aggregate/pom.xml
+++ b/Logblock-2-Aggregate/pom.xml
@@ -43,7 +43,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.0</version>
+                <version>2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
As per https://cwiki.apache.org/confluence/display/MAVEN/AetherClassNotFound certain plugins (in this case, the shade plugin) need a version bump or they won't work on maven 3.1
