### PR TITLE
Closing DataOutputStream before calling toByteArray on the underlying ByteArrayOutputStream

### DIFF
--- a/LogBlock-2-API/src/test/java/org/logblock/entry/BlobTest.java
+++ b/LogBlock-2-API/src/test/java/org/logblock/entry/BlobTest.java
@@ -22,6 +22,7 @@ public class BlobTest
         blobOut.setArt("artistic");
         blobOut.setDirection((byte) 5);
         blobOut.write(outStream);
+        outStream.close();
 
         DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(byteOutput.toByteArray()));
         PaintingBlob blobIn = BlobEntry.create(1, PaintingBlob.class);


### PR DESCRIPTION
When a DataOutputStream instance wraps an underlying ByteArrayOutputStream instance,
it is recommended to flush or close the DataOutputStream before invoking the underlying instances's toByteArray(). Also, it is a good practice to call flush/close explicitly as mentioned for example [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).
This pull request adds a close method before calling toByteArray().
